### PR TITLE
Make customization of config files more flexible and 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Any key/value pair from a config file can be added to the following dicts. Dict 
 
 ```yaml
 nifi_registry_properties:
-bootstrap:
-logback:
-identity_providers:
-authorizers:
-providers:
+nifi_registry_bootstrap:
+nifi_registry_logback:
+nifi_registry_identity_providers:
+nifi_registry_authorizers:
+nifi_registry_providers:
 ```
 
 ## Dependencies
@@ -85,7 +85,7 @@ Secure single node NiFi Registry instance with LDAP:
         nifi.registry.security.truststoreType: JKS
         nifi.registry.security.truststorePasswd: truststorePassword
         nifi.registry.security.needClientAuth: false
-      identity_providers:
+      nifi_registry_identity_providers:
         /loginIdentityProviders/provider/identifier: ldap-provider
         /loginIdentityProviders/provider/property[@name="Authentication Strategy"]: SIMPLE
         /loginIdentityProviders/provider/property[@name="Manager DN"]: cn=nifi-registry,ou=people,dc=example,dc=com
@@ -93,7 +93,7 @@ Secure single node NiFi Registry instance with LDAP:
         /loginIdentityProviders/provider/property[@name="Url"]: ldap://hostname:port
         /loginIdentityProviders/provider/property[@name="User Search Base"]: OU=people,DC=example,DC=com
         /loginIdentityProviders/provider/property[@name="User Search Filter"]: sAMAccountName={0}
-      authorizers:
+      nifi_registry_authorizers:
         /authorizers/userGroupProvider/property[@name="Initial User Identity 1"]: cn=John Smith,ou=people,dc=example,dc=com
         /authorizers/accessPolicyProvider/property[@name="Initial Admin Identity"]: cn=John Smith,ou=people,dc=example,dc=com
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,33 +20,33 @@ nifi_registry_config_dirs:
 # Specify any property from nifi-registry.properties here.
 nifi_registry_properties:
   nifi.registry.web.http.port: 18080
-  nifi.registry.security.identity.provider: "{{ identity_providers['/identityProviders/provider/identifier'] }}"
+  nifi.registry.security.identity.provider: "{{ nifi_registry_identity_providers['/identityProviders/provider/identifier'] }}"
   nifi.registry.db.url: "jdbc:h2:{{ nifi_registry_config_dirs.external_config }}/database/nifi-registry-primary;AUTOCOMMIT=OFF;DB_CLOSE_ON_EXIT=FALSE;LOCK_MODE=3;LOCK_TIMEOUT=25000;WRITE_DELAY=0;AUTO_SERVER=FALSE"
 
 # Specify any property from bootstrap.conf here.
-bootstrap:
+nifi_registry_bootstrap:
   java.arg.2: -Xms512m
   java.arg.3: -Xmx512m
 
 # Specify any property from logback.xml here.
 # Use XPath expressions as keys.
-logback:
+nifi_registry_logback:
   /configuration/appender[@name="APP_FILE"]/rollingPolicy/timeBasedFileNamingAndTriggeringPolicy/maxFileSize: 100MB
   /configuration/appender[@name="APP_FILE"]/rollingPolicy/maxHistory: 30
 
 # Specify any property from identity-providers.xml here.
 # Use XPath expressions as keys.
-identity_providers:
+nifi_registry_identity_providers:
   # Can be one of 'ldap-provider' or 'kerberos-provider'. Leave blank for no RBAC.
   /identityProviders/provider/identifier: ""
 
 # Specify any property from authorizers.xml here.
 # Use XPath expressions as keys.
-authorizers:
+nifi_registry_authorizers:
   /authorizers/userGroupProvider/identifier: file-user-group-provider
   /authorizers/userGroupProvider/property[@name="Users File"]: "{{ nifi_registry_config_dirs.external_config }}/users.xml"
   /authorizers/accessPolicyProvider/property[@name="Authorizations File"]: "{{ nifi_registry_config_dirs.external_config }}/authorizations.xml"
 
-providers:
+nifi_registry_providers:
   /providers/flowPersistenceProvider/property[@name="Flow Storage Directory"]: "{{ nifi_registry_config_dirs.external_config }}/flow_storage"
   /providers/extensionBundlePersistenceProvider/property[@name="Extension Bundle Storage Directory"]: "{{ nifi_registry_config_dirs.external_config }}/extension_bundles"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,6 @@
 ---
-- name: Populate service facts
-  ansible.builtin.service_facts:
-
-- debug:
-    msg: "WARNING: nifi-registry service was not detected, skipping adding handler on restart"
-  when: "not ansible_facts.services is defined or not 'nifi-registry' in ansible_facts.services"
-
-- name: Re/Start NiFi Registry
-  service:
+- name: restart_nifi_registry
+  systemd:
     name: nifi-registry
     state: restarted
-  when: "ansible_facts.services is defined and 'nifi-registry' in ansible_facts.services"
+    daemon_reload: yes

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -24,7 +24,7 @@
 
 - name: Update nifi-registry-env.sh
   lineinfile:
-    path: "{{ nifi_config_dirs.home }}/bin/nifi-registry-env.sh"
+    path: "{{ nifi_registry_config_dirs.home }}/bin/nifi-registry-env.sh"
     line: "export {{ item.key }}={{ item.value }}"
     regexp: "^export {{ item.key }}="
   with_dict: "{{ nifi_registry_env }}"

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -12,6 +12,7 @@
     line: "{{ item.key }}={{ item.value }}"
     regexp: "^{{ item.key }}"
   with_dict: "{{ nifi_registry_properties }}"
+  notify: restart_nifi_registry
 
 - name: Update bootstrap.conf
   lineinfile:
@@ -19,6 +20,15 @@
     line: "{{ item.key }}={{ item.value }}"
     regexp: "^{{ item.key }}"
   with_dict: "{{ bootstrap }}"
+  notify: restart_nifi_registry
+
+- name: Update nifi-registry-env.sh
+  lineinfile:
+    path: "{{ nifi_config_dirs.home }}/bin/nifi-registry-env.sh"
+    line: "export {{ item.key }}={{ item.value }}"
+    regexp: "^export {{ item.key }}="
+  with_dict: "{{ nifi_registry_env }}"
+  notify: restart_nifi_registry
 
 - name: Update logback.xml
   xml:
@@ -26,6 +36,7 @@
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
   with_dict: "{{ logback }}"
+  notify: restart_nifi_registry
 
 - name: Update identity-providers.xml
   block:
@@ -41,6 +52,7 @@
         value: "{{ item.value }}"
       with_dict: "{{ identity_providers }}"
   when: identity_providers['/identityProviders/provider/identifier'] | length
+  notify: restart_nifi_registry
 
 - name: Update authorizers.xml
   block:
@@ -56,6 +68,7 @@
         value: "{{ item.value }}"
       with_dict: "{{ authorizers }}"
   when: authorizers['/authorizers/userGroupProvider/identifier'] | length
+  notify: restart_nifi_registry
 
 - name: Update providers.xml
   xml:
@@ -63,3 +76,4 @@
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
   with_dict: "{{ providers }}"
+  notify: restart_nifi_registry

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -35,6 +35,7 @@
     path: "{{ nifi_registry_config_dirs.home }}/conf/logback.xml"
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
+    pretty_print: yes
   with_dict: "{{ logback }}"
   notify: restart_nifi_registry
 
@@ -50,6 +51,7 @@
         path: "{{ nifi_registry_config_dirs.home }}/conf/identity-providers.xml"
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
+        pretty_print: yes
       with_dict: "{{ identity_providers }}"
       notify: restart_nifi_registry
   when: identity_providers['/identityProviders/provider/identifier'] | length
@@ -66,14 +68,16 @@
         path: "{{ nifi_registry_config_dirs.home }}/conf/authorizers.xml"
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
+        pretty_print: yes
       with_dict: "{{ authorizers }}"
+      notify: restart_nifi_registry
   when: authorizers['/authorizers/userGroupProvider/identifier'] | length
-  notify: restart_nifi_registry
 
 - name: Update providers.xml
   xml:
     path: "{{ nifi_registry_config_dirs.home }}/conf/providers.xml"
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
+    pretty_print: yes
   with_dict: "{{ providers }}"
   notify: restart_nifi_registry

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -19,7 +19,7 @@
     path: "{{ nifi_registry_config_dirs.home }}/conf/bootstrap.conf"
     line: "{{ item.key }}={{ item.value }}"
     regexp: "^{{ item.key }}"
-  with_dict: "{{ bootstrap }}"
+  with_dict: "{{ nifi_registry_bootstrap }}"
   notify: restart_nifi_registry
 
 - name: Update nifi-registry-env.sh
@@ -36,7 +36,7 @@
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
     pretty_print: yes
-  with_dict: "{{ logback }}"
+  with_dict: "{{ nifi_registry_logback }}"
   notify: restart_nifi_registry
 
 - name: Update identity-providers.xml
@@ -44,7 +44,7 @@
     - name: Uncomment block in identity-providers.xml
       replace:
         path: "{{ nifi_registry_config_dirs.home }}/conf/identity-providers.xml"
-        regexp: "^.*To enable the {{ identity_providers['/identityProviders/provider/identifier'] }}.*$"
+        regexp: "^.*To enable the {{ nifi_registry_identity_providers['/identityProviders/provider/identifier'] }}.*$"
         replace: ""
     - name: Update properties in identity-providers.xml
       xml:
@@ -52,16 +52,16 @@
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
         pretty_print: yes
-      with_dict: "{{ identity_providers }}"
+      with_dict: "{{ nifi_registry_identity_providers }}"
       notify: restart_nifi_registry
-  when: identity_providers['/identityProviders/provider/identifier'] | length
+  when: nifi_registry_identity_providers['/identityProviders/provider/identifier'] | length
   
 - name: Update authorizers.xml
   block:
     - name: Uncomment block in authorizers.xml
       replace:
         path: "{{ nifi_registry_config_dirs.home }}/conf/authorizers.xml"
-        regexp: "^.*To enable the {{ authorizers['/authorizers/userGroupProvider/identifier'] }}.*$"
+        regexp: "^.*To enable the {{ nifi_registry_authorizers['/authorizers/userGroupProvider/identifier'] }}.*$"
         replace: ""
     - name: Update properties in authorizers.xml
       xml:
@@ -69,9 +69,9 @@
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
         pretty_print: yes
-      with_dict: "{{ authorizers }}"
+      with_dict: "{{ nifi_registry_authorizers }}"
       notify: restart_nifi_registry
-  when: authorizers['/authorizers/userGroupProvider/identifier'] | length
+  when: nifi_registry_authorizers['/authorizers/userGroupProvider/identifier'] | length
 
 - name: Update providers.xml
   xml:
@@ -79,5 +79,5 @@
     xpath: "{{ item.key }}"
     value: "{{ item.value }}"
     pretty_print: yes
-  with_dict: "{{ providers }}"
+  with_dict: "{{ nifi_registry_providers }}"
   notify: restart_nifi_registry

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -51,9 +51,9 @@
         xpath: "{{ item.key }}"
         value: "{{ item.value }}"
       with_dict: "{{ identity_providers }}"
+      notify: restart_nifi_registry
   when: identity_providers['/identityProviders/provider/identifier'] | length
-  notify: restart_nifi_registry
-
+  
 - name: Update authorizers.xml
   block:
     - name: Uncomment block in authorizers.xml


### PR DESCRIPTION
* environment variables can now be configured as well
* updating config files results in nifi registry reloading to pick up changes
* the following variables have been prepended with `nifi_registry_` to restrict scope, as otherwise conflicts with dictionaries with the same name defined in other ansible roles would happen when `hash_behaviour = merge`:
  - bootstrap -> `nifi_registry_bootstrap`
  - logback -> `nifi_registry_logback`
  - identity_providers -> `nifi_registry_identity_providers`
  - authorizers -> `nifi_registry_authorizers`
  - providers -> `nifi_registry_providers`