### PR TITLE
24 Added differentiation between root and non-root tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,10 @@ nifi_registry_bootstrap:
   java.arg.2: -Xms512m
   java.arg.3: -Xmx512m
 
+# Specify any property from nifi-env.sh here.
+nifi_registry_env:
+  NIFI_REGISTRY_HOME: "{{ nifi_registry_config_dirs.home }}"
+
 # Specify any property from logback.xml here.
 # Use XPath expressions as keys.
 nifi_registry_logback:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,13 @@
 ---
 - name: restart_nifi_registry
+  become: yes
+  # become_user: "{{ nifi_registry_user }}"
   systemd:
     name: nifi-registry
     state: restarted
-    daemon_reload: yes
+  #   scope: user
+  # environment:
+  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+  tags:
+  - root
+  - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,21 +1,18 @@
 ---
-- name: restart_nifi_registry
-  become: yes
-  #become_user: "{{ nifi_registry_user }}"
-  systemd:
-    name: nifi-registry
-    state: restarted
-  #   scope: user
-  # environment:
-  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
-  tags:
-  - root
-  # - no-root
-
+# Performs the restart of the service as root
 # - name: restart_nifi_registry
 #   become: yes
-#   become_user: "{{ nifi_registry_user }}"
-#   command: sudo systemctl restart nifi-registry
+#   systemd:
+#     name: nifi-registry
+#     state: restarted
 #   tags:
 #   - root
 #   - no-root
+
+- name: restart_nifi_registry
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
+  command: sudo systemctl restart nifi-registry
+  tags:
+  - root
+  - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: restart_nifi_registry
   become: yes
-  # become_user: "{{ nifi_registry_user }}"
+  become_user: "{{ nifi_registry_user }}"
   systemd:
     name: nifi-registry
     state: restarted
-  #   scope: user
-  # environment:
-  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
   tags:
   - root
   - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,10 +12,10 @@
 #   - root
 #   - no-root
 
-- name: restart_nifi
+- name: restart_nifi_registry
   become: yes
-  become_user: "{{ nifi_user }}"
-  command: sudo systemctl restart nifi
+  become_user: "{{ nifi_registry_user }}"
+  command: sudo systemctl restart nifi-registry
   tags:
   - root
   - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,9 +5,9 @@
   systemd:
     name: nifi-registry
     state: restarted
-    scope: user
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+  #   scope: user
+  # environment:
+  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
   tags:
   - root
   - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,21 @@
 ---
-- name: restart_nifi_registry
+# - name: restart_nifi_registry
+#   become: yes
+#   become_user: "{{ nifi_registry_user }}"
+#   systemd:
+#     name: nifi-registry
+#     state: restarted
+#   #   scope: user
+#   # environment:
+#   #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+#   tags:
+#   - root
+#   - no-root
+
+- name: restart_nifi
   become: yes
-  become_user: "{{ nifi_registry_user }}"
-  systemd:
-    name: nifi-registry
-    state: restarted
-  #   scope: user
-  # environment:
-  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+  become_user: "{{ nifi_user }}"
+  command: sudo systemctl restart nifi
   tags:
   - root
   - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,21 +1,21 @@
 ---
+- name: restart_nifi_registry
+  become: yes
+  #become_user: "{{ nifi_registry_user }}"
+  systemd:
+    name: nifi-registry
+    state: restarted
+  #   scope: user
+  # environment:
+  #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+  tags:
+  - root
+  # - no-root
+
 # - name: restart_nifi_registry
 #   become: yes
 #   become_user: "{{ nifi_registry_user }}"
-#   systemd:
-#     name: nifi-registry
-#     state: restarted
-#   #   scope: user
-#   # environment:
-#   #   XDG_RUNTIME_DIR: "/run/user/{{ myuid_nifi_registry.stdout }}"
+#   command: sudo systemctl restart nifi-registry
 #   tags:
 #   - root
 #   - no-root
-
-- name: restart_nifi_registry
-  become: yes
-  become_user: "{{ nifi_registry_user }}"
-  command: sudo systemctl restart nifi-registry
-  tags:
-  - root
-  - no-root

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,14 +1,4 @@
 ---
-# Performs the restart of the service as root
-# - name: restart_nifi_registry
-#   become: yes
-#   systemd:
-#     name: nifi-registry
-#     state: restarted
-#   tags:
-#   - root
-#   - no-root
-
 - name: restart_nifi_registry
   become: yes
   become_user: "{{ nifi_registry_user }}"

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -1,4 +1,10 @@
 ---
+- name: Get NiFi Registry UserID
+  become: true
+  become_user: "{{ nifi_registry_user }}"
+  command: id -u
+  register: myuid_nifi_registry
+
 - name: Create shared resources directory
   file:
     path: "{{ nifi_registry_config_dirs.external_config }}"

--- a/tasks/customize.yml
+++ b/tasks/customize.yml
@@ -1,10 +1,4 @@
 ---
-- name: Get NiFi Registry UserID
-  become: true
-  become_user: "{{ nifi_registry_user }}"
-  command: id -u
-  register: myuid_nifi_registry
-
 - name: Create shared resources directory
   file:
     path: "{{ nifi_registry_config_dirs.external_config }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,16 +37,16 @@
   - root
   - no-root
 
-# - name: Fix permissions for lineinfile
-#   become: yes
-#   file:
-#     path: "/tmp/.ansible"
-#     state: directory
-#     owner: "{{ nifi_registry_user }}"
-#     group: "{{ nifi_registry_group }}"
-#     recurse: "yes"
-#   tags:
-#   - root
+- name: Fix permissions for lineinfile
+  become: yes
+  file:
+    path: "/tmp/.ansible"
+    state: directory
+    owner: "{{ nifi_registry_user }}"
+    group: "{{ nifi_registry_group }}"
+    recurse: "yes"
+  tags:
+  - root
 
 - name: Fix permissions
   become: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,6 +37,17 @@
   - root
   - no-root
 
+- name: Fix permissions for lineinfile
+  become: yes
+  file:
+    path: "/tmp/.ansible"
+    state: directory
+    owner: "{{ nifi_registry_user }}"
+    group: "{{ nifi_registry_group }}"
+    recurse: "yes"
+  tags:
+  - root
+
 - name: Fix permissions
   become: yes
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,19 +1,31 @@
 ---
 - name: Check if NiFi Registry binary exists
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
   stat:
     path: "{{ nifi_registry_config_dirs.binaries }}/nifi-registry-{{ nifi_registry_version }}-bin.zip"
     get_attributes: no
     get_checksum: no
     get_mime: no
   register: zip_file
+  tags:
+  - root
+  - no-root
 
 - name: Download NiFi Registry binary
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
   get_url:
     url: "{{ download_mirror_uri }}/nifi/{{ nifi_registry_version }}/nifi-registry-{{ nifi_registry_version }}-bin.zip"
     dest: "{{ nifi_registry_config_dirs.binaries }}/nifi-registry-{{ nifi_registry_version }}-bin.zip"
   when: not zip_file.stat.exists
+  tags:
+  - root
+  - no-root
 
 - name: Unpack NiFi Registry binary
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
   unarchive:
     remote_src: "yes"
     src: "{{ nifi_registry_config_dirs.binaries }}/nifi-registry-{{ nifi_registry_version }}-bin.zip"
@@ -21,18 +33,29 @@
     owner: "{{ nifi_registry_user }}"
     group: "{{ nifi_registry_group }}"
     creates: "{{ nifi_registry_config_dirs.install }}/nifi-registry-{{ nifi_registry_version }}"
+  tags:
+  - root
+  - no-root
 
 - name: Fix permissions
+  become: yes
   file:
     path: "{{ nifi_registry_config_dirs.install }}/nifi-registry-{{ nifi_registry_version }}"
     owner: "{{ nifi_registry_user }}"
     group: "{{ nifi_registry_group }}"
     recurse: "yes"
+  tags:
+  - root
 
 - name: Create NiFi Registry symlink
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
   file:
     src: "nifi-registry-{{ nifi_registry_version }}"
     path: "{{ nifi_registry_config_dirs.home }}"
     state: "link"
     owner: "{{ nifi_registry_user }}"
     group: "{{ nifi_registry_group }}"
+  tags:
+  - root
+  - no-root

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,16 +37,16 @@
   - root
   - no-root
 
-- name: Fix permissions for lineinfile
-  become: yes
-  file:
-    path: "/tmp/.ansible"
-    state: directory
-    owner: "{{ nifi_registry_user }}"
-    group: "{{ nifi_registry_group }}"
-    recurse: "yes"
-  tags:
-  - root
+# - name: Fix permissions for lineinfile
+#   become: yes
+#   file:
+#     path: "/tmp/.ansible"
+#     state: directory
+#     owner: "{{ nifi_registry_user }}"
+#     group: "{{ nifi_registry_group }}"
+#     recurse: "yes"
+#   tags:
+#   - root
 
 - name: Fix permissions
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,20 @@
 ---
 - name: Prepare system
+  become: yes
   import_tasks: prepare.yml
+  tags:
+  - root
 
 - name: Install NiFi Registry
   import_tasks: install.yml
 
 - name: Customize NiFi Registry
+  become: yes
+  become_user: "{{ nifi_registry_user }}"
   import_tasks: customize.yml
 
 - name: Run NiFi Registry as system service
+  become: yes
   import_tasks: run.yml
+  tags:
+  - root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,9 @@
   become: yes
   become_user: "{{ nifi_registry_user }}"
   import_tasks: customize.yml
+  tags:
+  - root
+  - no-root
 
 - name: Run NiFi Registry as system service
   become: yes

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -8,6 +8,6 @@
   systemd:
     name: nifi-registry
     state: restarted
-    daemon_reload: yes
     enabled: yes
+    daemon_reload: yes
     

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -7,6 +7,7 @@
 - name: Enable NiFi Registry service
   systemd:
     name: nifi-registry
+    state: restarted
     daemon_reload: yes
     enabled: yes
-    state: restarted
+    


### PR DESCRIPTION
Tasks in the nifi registry role have been differentiated in tasks that require root permissions and tasks that doesn't.
This is something that allows to install nifi registry by leveraging the nifi_registry user, given that all the tasks that require root permissions had already been performed beforehand