### PR TITLE
Remove useless permissions task

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -37,17 +37,6 @@
   - root
   - no-root
 
-- name: Fix permissions for lineinfile
-  become: yes
-  file:
-    path: "/tmp/.ansible"
-    state: directory
-    owner: "{{ nifi_registry_user }}"
-    group: "{{ nifi_registry_group }}"
-    recurse: "yes"
-  tags:
-  - root
-
 - name: Fix permissions
   become: yes
   file:


### PR DESCRIPTION
Removed task which assigns ownership of /tmp/.ansible user to the nifiregistry user, this is not needed